### PR TITLE
IALERT-3188: Remove Unused GSon Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,35 @@ An application used for indexing issue properties to allow Alert to map notifica
 You can download the latest from GitHub: https://github.com/blackducksoftware/alert-issue-property-indexer/releases
 
 ## Documentation ##
-TBD
+
+This plugin only creates a database index inside of Jira. 
+
+
+### Generating a security scanner report ###
+Use the following commands to generate an OWASP security scanner report:
+
+Atlassian SDK:
+```
+atlas-mvn verify
+```
+OR 
+
+Maven:
+```
+mvn verify
+```
+These commands will create the `dependency-check-report.html` file in the target directory.
+
+### Generating a Dependency Tree File ###
+
+Atlassian SDK:
+```
+atlas-mvn dependency:tree -DoutputType=dot -DoutputFile=maven_dependency_tree.gv
+```
+OR
+
+Maven: 
+```
+mvn dependency:tree -DoutputType=dot -DoutputFile=maven_dependency_tree.gv
+```
+These commands create a file `maven_dependency_tree.gv` file in the directory where the command is run.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ You can download the latest from GitHub: https://github.com/blackducksoftware/al
 
 This plugin only creates a database index inside of Jira. 
 
+### Atlassian SDK Installation ###
+
+The Atlassian SDK can be found here: https://marketplace.atlassian.com/apps/1210993/atlassian-plugin-sdk-tgz?tab=overview&hosting=server
+
+Installation Instructions: https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system/
+
+ - Follow the instructions to perform a manual install of the tgz file to avoid OS dependency issues. 
+
+SDK Versions: https://marketplace.atlassian.com/apps/1210993/atlassian-plugin-sdk-tgz/version-history
 
 ### Generating a security scanner report ###
 Use the following commands to generate an OWASP security scanner report:

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
             <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.2-atlassian-1</version>
-        </dependency>
 
         <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
         <!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->
@@ -242,6 +237,22 @@
                     </scannedDependencies>
                     <verbose>false</verbose>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.owasp</groupId>
+              <artifactId>dependency-check-maven</artifactId>
+              <version>7.3.0</version>
+                <configuration>
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <suppressionFile>https://dcapt-downloads.s3.amazonaws.com/atlassian-security-scanner-dc-apps-suppressions.xml</suppressionFile>
+                </configuration>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Remove the dependency on Gson.  
- Tested alert can still find and update issues with Alert.
- Used atlassian SDK 8.0.16 