### PR TITLE
IALERT-3715 Identifier changes to blackduck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.synopsys.integration.alert</groupId>
+    <groupId>com.blackduck.integration.alert</groupId>
     <artifactId>alert-jira-property-indexer</artifactId>
     <version>0.0.6-SNAPSHOT</version>
 
@@ -49,7 +49,7 @@
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
-        <atlassian.plugin.key>com.synopsys.integration.alert</atlassian.plugin.key>
+        <atlassian.plugin.key>com.blackduck.integration.alert</atlassian.plugin.key>
         <!-- TestKit version 6.x for JIRA 6.x -->
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -193,7 +193,7 @@
 
                         <!-- Add package to export here -->
                         <Export-Package>
-                            com.synopsys.integration.alert.api,
+                            com.blackduck.integration.alert.api,
                         </Export-Package>
 
                         <!-- Add package import here -->

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -9,8 +9,8 @@
         <param name="plugin-logo">images/BlackDuckIcon.png</param>
     </plugin-info>
 
-    <index-document-configuration entity-key="IssueProperty" key="com-synopsys-integration-alert">
-        <key property-key="com-synopsys-integration-alert">
+    <index-document-configuration entity-key="IssueProperty" key="com-blackduck-integration-alert">
+        <key property-key="com-blackduck-integration-alert">
             <extract path="name" type="string"/>
             <extract path="provider" type="string"/>
             <extract path="providerUrl" type="string"/>

--- a/src/main/resources/cloud/atlassian-connect.json
+++ b/src/main/resources/cloud/atlassian-connect.json
@@ -1,7 +1,7 @@
 {
   "name": "Alert Issue Property Indexer",
   "description": "An application used for indexing issue properties to allow Alert to map notifications to the correct issue(s).",
-  "key": "com.synopsys.integration.alert",
+  "key": "com.blackduck.integration.alert",
   "baseUrl": "https://github.com/blackducksoftware/blackduck-alert",
   "vendor": {
     "name": "Black Duck Software, Inc.",
@@ -14,14 +14,14 @@
   "modules": {
     "jiraEntityProperties": [
       {
-        "key": "com-synopsys-integration-alert",
+        "key": "com-blackduck-integration-alert",
         "name": {
           "value": "Alert Issue Property"
         },
         "entityType": "issue",
         "keyConfigurations": [
           {
-            "propertyKey": "com-synopsys-integration-alert",
+            "propertyKey": "com-blackduck-integration-alert",
             "extractions": [
               {
                 "objectName": "provider",


### PR DESCRIPTION
Key identifiers renamed to blackduck to publish as a new app. See key field for more details: https://developer.atlassian.com/server/framework/atlassian-sdk/atlassian-plugin-xml-element-reference/. Requires technical review.