### PR TITLE
IALERT-3834 - Update to work with Jira 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,14 +192,6 @@
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
 
                         <!-- Add package to export here -->
-                <Import-Package>
-                    com.atlassian.plugin.spring.scanner.*,
-                    org.springframework.beans.factory.xml,
-                    org.springframework.beans.factory.parsing,
-                    org.springframework.core.io,
-                    org.xml.sax,
-                    *
-                </Import-Package>
                         <Export-Package>
                             com.blackduck.integration.alert.api,
                         </Export-Package>
@@ -255,27 +247,6 @@
                   </execution>
               </executions>
             </plugin>
-<plugin>
-  <groupId>org.apache.felix</groupId>
-  <artifactId>maven-bundle-plugin</artifactId>
-  <version>5.1.9</version>
-  <extensions>true</extensions>
-  <configuration>
-    <instructions>
-      <Import-Package>
-        com.atlassian.plugin.spring.scanner.runtime,
-        com.atlassian.plugin.spring.scanner.*,
-        org.springframework.beans.factory.xml,
-        org.springframework.beans.factory.parsing,
-        org.springframework.core.io,
-        org.xml.sax,
-        *
-      </Import-Package>
-      <Export-Package>com.blackduck.integration.alert.api</Export-Package>
-      <Spring-Context>*</Spring-Context>
-    </instructions>
-  </configuration>
-</plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,17 @@
     </distributionManagement>
 
     <properties>
-        <jira.version>9.12.0</jira.version>
-        <amps.version>8.11.2</amps.version>
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <jira.version>10.5.0</jira.version>
+        <amps.version>8.17.0</amps.version>
+        <plugin.testrunner.version>2.0.0</plugin.testrunner.version>
+        <atlassian.spring.scanner.version>5.1.0</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>com.blackduck.integration.alert</atlassian.plugin.key>
         <!-- TestKit version 6.x for JIRA 6.x -->
         <testkit.version>6.3.11</testkit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -121,14 +121,14 @@
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-runtime</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -171,7 +171,7 @@
                 <artifactId>jira-maven-plugin</artifactId>
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
-                <configuration>
+		 <configuration>
                     <productVersion>${jira.version}</productVersion>
                     <productDataVersion>${jira.version}</productDataVersion>
                     <!-- Uncomment to install TestKit backdoor in JIRA. -->
@@ -192,6 +192,14 @@
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
 
                         <!-- Add package to export here -->
+                <Import-Package>
+                    com.atlassian.plugin.spring.scanner.*,
+                    org.springframework.beans.factory.xml,
+                    org.springframework.beans.factory.parsing,
+                    org.springframework.core.io,
+                    org.xml.sax,
+                    *
+                </Import-Package>
                         <Export-Package>
                             com.blackduck.integration.alert.api,
                         </Export-Package>
@@ -247,6 +255,27 @@
                   </execution>
               </executions>
             </plugin>
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-bundle-plugin</artifactId>
+  <version>5.1.9</version>
+  <extensions>true</extensions>
+  <configuration>
+    <instructions>
+      <Import-Package>
+        com.atlassian.plugin.spring.scanner.runtime,
+        com.atlassian.plugin.spring.scanner.*,
+        org.springframework.beans.factory.xml,
+        org.springframework.beans.factory.parsing,
+        org.springframework.core.io,
+        org.xml.sax,
+        *
+      </Import-Package>
+      <Export-Package>com.blackduck.integration.alert.api</Export-Package>
+      <Spring-Context>*</Spring-Context>
+    </instructions>
+  </configuration>
+</plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.blackduck.integration.alert</groupId>
     <artifactId>alert-jira-property-indexer</artifactId>
-    <version>0.0.7-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <organization>
         <name>Black Duck Software, Inc.</name>

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
+       xmlns:scanner="http://www.atlassian.com/schema/atlassian-scanner"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+        http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.atlassian.com/schema/atlassian-scanner
         http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
-    <atlassian-scanner:scan-indexes/>
+    <scanner:scan-indexes/>
 </beans>

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:scanner="http://www.atlassian.com/schema/atlassian-scanner"
+       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
-    <scanner:scan-indexes/>
+        http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
+
+    <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
Update version to 0.1.0 (to differentiate with versions before Jira 10)
Update dependencies and URL's to those supported by Jira 10
